### PR TITLE
Suggest using current user's name

### DIFF
--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -9,6 +9,7 @@ const NavBar = () => {
       role="nav"
       className="d-flex d-lg-none justify-content-end align-items-center background-purple-light nav-bar"
     >
+      // see comment
       <div className="nav-bar-text">Jasmine</div>
       <div>
         <button className="small-button purple-solid nav-bar-button">Log out</button>


### PR DESCRIPTION
It looks like the navbar is hardcoded to have the name "Jasmine" rather than the current user's name — could be cool to personalize this section by fetching the current user's name each time!